### PR TITLE
feat: 캔버스 UI/UX 개선

### DIFF
--- a/src/pages/canvas/components/CanvasSection.module.css
+++ b/src/pages/canvas/components/CanvasSection.module.css
@@ -21,4 +21,30 @@
     gap: 10px;
     color: #347050;
     font-weight: bold;
+}
+
+.canvasBackground {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+
+.canvas {
+    position: relative;
+    z-index: 2;
+}
+
+.bannerSectiontitle {
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 2rem;
+    color: #ffffff;
+    font-family: 'Song Myung', serif;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+    pointer-events: none;
 } 

--- a/src/pages/canvas/components/CanvasSection.tsx
+++ b/src/pages/canvas/components/CanvasSection.tsx
@@ -27,7 +27,6 @@ const CanvasSection = ({ uploadCanvasImage, canvasRef, handleChange, handleSaveC
   const [isPanelVisible, setIsPanelVisible] = useState(false);
   const [imageData, setImageData] = useState<any>(null);
   const [currentFeedback, setCurrentFeedback] = useState<string | null>(null);
-  const [isImageCardCollapsed, setIsImageCardCollapsed] = useState(false);
   const [currentStep, setCurrentStep] = useState(0);
   const [secondfeedback, setSecondfeedback] = useState<string>('');
 
@@ -188,7 +187,7 @@ const CanvasSection = ({ uploadCanvasImage, canvasRef, handleChange, handleSaveC
         const nextStep = currentStep + 1;
         setCurrentStep(nextStep);
         setImageData({
-          title: title[nextStep],
+          title: title[nextStep -1],
           description: instructions[nextStep],
           image: imageUrl
         });
@@ -200,11 +199,6 @@ const CanvasSection = ({ uploadCanvasImage, canvasRef, handleChange, handleSaveC
     }
   };
   
-  const toggleImageCard = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsImageCardCollapsed(!isImageCardCollapsed);
-  };
-
   // 컴포넌트 언마운트 시 오디오 정리
   useEffect(() => {
     return () => {
@@ -234,6 +228,9 @@ const CanvasSection = ({ uploadCanvasImage, canvasRef, handleChange, handleSaveC
       onMouseMove={handleMouseMove} 
       onMouseUp={() => handleMouseUp(handleChange)}
     >
+      <div className={style.canvasBackground}>
+        {showTitle && <div className={style.bannerSectiontitle}>{instructions[currentStep-1]}</div>}
+      </div>
       <BannerSection
         onSave={saveImageAndFeedback}
         step={currentStep}
@@ -243,12 +240,9 @@ const CanvasSection = ({ uploadCanvasImage, canvasRef, handleChange, handleSaveC
         className={style.canvas} 
         id="mycanvas"
       />
-      {showTitle && <div className={style.bannerSectiontitle}>{instructions[currentStep-1]}</div>}
       {imageData && (
         <ImagePanelSection 
           imageData={imageData}
-          isImageCardCollapsed={isImageCardCollapsed}
-          toggleImageCard={toggleImageCard}
         />
       )}
       {currentFeedback && isPanelVisible && (

--- a/src/pages/canvas/components/PanelSection.module.css
+++ b/src/pages/canvas/components/PanelSection.module.css
@@ -1,0 +1,28 @@
+.imageData {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    width: 300px;
+    z-index: 1000;
+}
+
+.imageDataContent {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 15px;
+    padding: 15px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.imageDataContent img {
+    width: 100%;
+    height: auto;
+    border-radius: 10px;
+}
+
+.title {
+    font-size: 1.8rem;
+    color: #347050;
+    font-weight: bold;
+    margin-top: 5px;
+    text-align: center;
+} 

--- a/src/pages/canvas/components/PanelSection.tsx
+++ b/src/pages/canvas/components/PanelSection.tsx
@@ -1,4 +1,4 @@
-import style from "../CanvasPage.module.css";
+import style from "./PanelSection.module.css";
 
 interface ImagePanelProps {
   imageData: {
@@ -6,39 +6,16 @@ interface ImagePanelProps {
     description: string;
     image: string;
   };
-  isImageCardCollapsed: boolean;
-  toggleImageCard: (e: React.MouseEvent) => void;
 }
 
-const ChevronIcon = () => (
-    <svg 
-        width="24" 
-        height="24" 
-        viewBox="0 0 24 24" 
-        fill="none" 
-        stroke="currentColor" 
-        strokeWidth="2"
-    >
-        <path d="M18 6L6 18M6 6l12 12" />
-    </svg>
-);
-
-const ImagePanelSection = ({ imageData, isImageCardCollapsed, toggleImageCard }: ImagePanelProps) => {
+const ImagePanelSection = ({ imageData }: ImagePanelProps) => {
   return (
     <div 
-        className={`${style.imageData}`}
-        onClick={toggleImageCard}
+        className={style.imageData}
     >
-        <div className={`${style.imageDataContent} ${isImageCardCollapsed ? style.collapsed : ''}`}>
-            <div className={style.imageRow}>
-                <img src={imageData.image} alt={imageData.description} />
-                <div className={`${style.toggleIcon} ${isImageCardCollapsed ? style.toggleIconRotated : ''}`}>
-                    <ChevronIcon />
-                </div>
-            </div>
-            <div className={style.description}>
-                <div className={style.title}>{imageData.title}</div>
-            </div>
+        <div className={style.imageDataContent}>
+            <img src={imageData.image} alt={imageData.description} />
+            <div className={style.title}>{imageData.title}</div>
         </div>
     </div>
   );


### PR DESCRIPTION
캔버스 레이어 구조 개선:
- 캔버스 배경 레이어 추가로 그리기 작업 방해 요소 제거
- 지시사항 텍스트를 캔버스 아래 레이어로 이동
- pointer-events 조정으로 마우스 이벤트 간섭 방지

이미지 패널 UI 개선:
- 패널 위치를 오른쪽 하단으로 이동
- 불필요한 접기/펼치기 기능 제거
- 이미지와 타이틀만 표시하도록 단순화
- 타이틀 폰트 크기 1.8rem으로 증가

버그 수정:
- 이미지 패널의 스타일 모듈 경로 수정
- 단계별 타이틀 인덱스 오류 수정 (nextStep - 1)

변경된 파일:
- src/pages/canvas/components/CanvasSection.tsx
- src/pages/canvas/components/PanelSection.tsx
- src/pages/canvas/components/PanelSection.module.css